### PR TITLE
Declaring & initializing the DEFAULT_MESSAGE used in the answer function

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,8 +14,8 @@ const {
 } = require('./messages');
 
 // Botfuel App credentials
-const appId = '518d51a9';
-const appKey = '3d677c50843ca63f3e2cdd5b6fafe705';
+const appId = '<YOUR_APP_ID>';
+const appKey = '<YOUR_APP_KEY>';
 
 const spellchecker = new Spellchecking({ appId, appKey });
 const QnAClient = new QnA({ appId, appKey });

--- a/app.js
+++ b/app.js
@@ -10,11 +10,12 @@ const {
   BOT_SAY_GOODBYE,
   BOT_ASK_FOR_SELECT_ACTION,
   BOT_RECALL_USER_QUESTION,
+  DEFAULT_MESSAGE,
 } = require('./messages');
 
 // Botfuel App credentials
-const appId = '<YOUR_APP_ID>';
-const appKey = '<YOUR_APP_KEY>';
+const appId = '518d51a9';
+const appKey = '3d677c50843ca63f3e2cdd5b6fafe705';
 
 const spellchecker = new Spellchecking({ appId, appKey });
 const QnAClient = new QnA({ appId, appKey });

--- a/messages.js
+++ b/messages.js
@@ -9,6 +9,7 @@ module.exports = {
   BOT_ASK_FOR_SELECT_ACTION:
     'Je ne suis pas sur de comprendre, aidez-moi à choisir:',
   BOT_RECALL_USER_QUESTION: 'Vous avez demandé:',
+  DEFAULT_MESSAGE: 'Message par défaut',
   isGreetings: text => {
     return GREETINGS.some(word => word === text.toLowerCase());
   },


### PR DESCRIPTION
If missing, you always get the following error if the bot doesn't understand the question

`UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 3): ReferenceError: DEFAULT_MESSAGE is not defined`